### PR TITLE
Docs - clarify what props can be passed to islands

### DIFF
--- a/docs/concepts/islands.md
+++ b/docs/concepts/islands.md
@@ -32,8 +32,15 @@ An island can be used in a page like a regular Preact component. Fresh will take
 care of automatically re-hydrating the island on the client.
 
 Passing props to islands is supported, but only if the props are JSON
-serializable. This means that you can only pass primitive types, plain objects,
-and arrays. It is currently not possible to pass complex objects like `Date`,
+serializable. This means that you can only pass:
+
+* Primitive types `string`, `boolean`, and `null`
+* Most `number`s (`Infinity`, `-Infinity`, and `NaN` are silently converted to
+  `null`, and `bigint`s are not supported)
+* Plain objects with string keys and primitive, plain object, or array values
+* Arrays containing primitives, plain objects, or other arrays
+
+It is currently not possible to pass complex objects like `Date`,
 custom classes, or functions. This means that it is not possible to pass
 `children` to an island, as `children` are VNodes, which are not serializable.
 


### PR DESCRIPTION
I was caught out by trying to pass `Infinity` as a prop to an island, which is a valid IEEE 754 float, but bizarrely JSON serializes to `null`.